### PR TITLE
Fixes arg expectation

### DIFF
--- a/src/utils/timer-test.js
+++ b/src/utils/timer-test.js
@@ -134,13 +134,7 @@ describes.realWin('Timer', {}, env => {
   it('timeoutPromise - race no timeout', () => {
     windowMock
       .expects('setTimeout')
-      .withExactArgs(
-        sandbox.match(value => {
-          value();
-          return true;
-        }),
-        111
-      )
+      .withExactArgs(sandbox.match(fn => typeof fn === 'function'), 111)
       .returns(1)
       .once();
 


### PR DESCRIPTION
Looks like a similar fix was made to the same test in the `amphtml` project
https://github.com/ampproject/amphtml/blob/master/test/unit/test-timer.js#L141-L144